### PR TITLE
fixed variable value updating in page update

### DIFF
--- a/lib/lordicon.dart
+++ b/lib/lordicon.dart
@@ -283,8 +283,17 @@ class IconViewerState extends State<IconViewer> with TickerProviderStateMixin {
     super.dispose();
   }
 
+  void updateClassVariable() {
+    _controller = widget.controller;
+    _width = widget.width;
+    _height = widget.height;
+    _colorize = widget.colorize;
+  }
+
   @override
   Widget build(BuildContext context) {
+    updateClassVariable();
+    
     var delegates = _colorize != null
         ? LottieDelegates(
             values: [


### PR DESCRIPTION
when the page is updated the values ​​of the variables are not updated, this makes it impossible to update some properties such as the color of the icon. It happens because it doesn't go through the InitState() function but goes directly into the build function and therefore keeps the old value of the variables